### PR TITLE
Få output för electrotest och exemplet att matcha

### DIFF
--- a/electrotest.c
+++ b/electrotest.c
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include <stdio.h>
+#include <math.h>
 #include "libresistance.h"
 #include "libpower.h"
 #include "libcomponent.h"
@@ -18,7 +19,7 @@ int main() {
   scanf("%f", &volt);
   clearInputBuffer();
 
-  printf("Ange koppling [P | S]: ");
+  printf("Ange koppling [S | P]: ");
   scanf("%c", &conn);
   clearInputBuffer();
 
@@ -45,7 +46,8 @@ int main() {
 
   // compute power
   float power = calc_power_r(volt, resistance);
-  printf("Effekt:\n%.2f W\n", power);
+  // truncate before printing, so it's not rounded by printf
+  printf("Effekt:\n%.2f W\n", trunc(power*100.0)/100.0);
 
   // figure out what three resistors to use
   float* res_array = (float*) malloc(3 * sizeof(float));


### PR DESCRIPTION
All väsentlig funktion fanns i electrotest (bra jobbat @jolars!), men hittade några småskillnader mellan vår output och exemplet.
```diff
2c2
< Ange koppling[S | P]: S
---
> Ange koppling [P | S]: S
8c8
< 1398,0 ohm
---
> 1398.0 ohm
10c10
< 1.78 W
---
> 1.79 W
```

Avrundningen nämndes i den tidigare pull requesten, bör den överensstämma med det givna exemplet eller inte? Man kan ju tolka det som att exemplet inte stämmer.

Skillnaden mellan ``1398,0 ohm`` och ``1398.0 ohm`` har jag inte åtgärdat, tänker att det faktiskt är ett fel i exemplet, då de i övrigt har använt punkt som decimaltecken.

Vad tror ni?
Tänker att det här är det sista vi behöver göra/ta ett beslut om?